### PR TITLE
Fix build and makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ manager: fmt vet
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: fmt vet
-	go run ./pkg/must-gather-rest-wrapper.go
+	go run ./pkg/must-gather-api.go
 
 # Run go fmt against code
 fmt:

--- a/pkg/backend/gathering_test.go
+++ b/pkg/backend/gathering_test.go
@@ -18,7 +18,6 @@ func TestMustGatherExec(t *testing.T) {
 
 	// Ensure empty destinationDir and mock command exec
 	os.RemoveAll("/tmp/must-gather-result-1")
-	cmdExecCombinedOutput = cmdMockCombinedOutput
 
 	// Exec the gathering
 	MustGatherExec(&gathering, db, "must-gather.tar.gz")


### PR DESCRIPTION
The `must-gather-rest-wrapper.go` no longer exists so the makefile was not working properly.
And the variable `cmdExecCombinedOutput` was never used so we could not build the project.